### PR TITLE
update icon on ASK AI widget

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -51,7 +51,7 @@
   data-text="Ask AI" 
   data-link="https://gurubase.io/g/hiddify-manager" 
   data-bg-color="#d5d0f8" 
-  data-icon-url="https://gurubase.io/_next/image?url=https%3A%2F%2Favatars.githubusercontent.com%2Fu%2F75415501%3Fs%3D200%26v%3D4&w=96&q=75" 
+  data-icon-url="https://avatars.githubusercontent.com/u/126981719?s=48&v=4" 
   data-font-color="#000000" 
   data-margins='{"bottom": "1rem", "right": "1rem"}'>
   </script>


### PR DESCRIPTION
The icon on the ASK AI widget currently shows the Anteon logo. I have changed it to the Hiddify logo.

<img width="499" alt="image" src="https://github.com/user-attachments/assets/4030ca37-298c-41e4-8d09-913cf36335e7" />
